### PR TITLE
Add a Community-driven guideline

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -64,6 +64,13 @@ Mention that the guide is not set in stone, and is a living document.
 
 Make it clear that the guide is a community effort, and everyone is welcome to contribute and discuss.
 
+[#community-driven]
+=== Community-driven
+
+Make sure that any change getting its way to the guide is community-driven.
+Use https://github.com/rubocop-hq/blog.rubystyle.guide/[the blog] to announce proposed changes.
+Lead the discussion on GitHub.
+
 [#keep-it-tidy]
 === Keep it Tidy
 


### PR DESCRIPTION
Singe [the blog](https://blog.rubystyle.guide/) been recently launched, it's a good option to announce the proposed changes for all the guides (eventually split with tags to distinguish between the guides).

Reddit/Slashdot/HackerNews are usual places to announce about an upcoming discussion, but probably not the best place for discussion itself, due to tendency of people expressing their views with no mutual respect.

GitHub, in contrary, is known to be a better place for discussions, as people tend to express their points of views in a more professional way.

[Floating-point Division](https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html) is a good example of a proposed change.